### PR TITLE
Command to reload Nuvotifier configurations in Sponge

### DIFF
--- a/bukkit/src/main/java/com/vexsoftware/votifier/NuVotifierBukkit.java
+++ b/bukkit/src/main/java/com/vexsoftware/votifier/NuVotifierBukkit.java
@@ -111,9 +111,6 @@ public class NuVotifierBukkit extends JavaPlugin implements VoteHandler, Votifie
         // Set the plugin version.
         version = getDescription().getVersion();
         reloadConfigs();
-
-
-
     }
 
     @Override
@@ -325,7 +322,11 @@ public class NuVotifierBukkit extends JavaPlugin implements VoteHandler, Votifie
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String commandLabel, String[] args){
         if(cmd.getName().equalsIgnoreCase("nvreload")){
-            reloadConfigs();
+            if(reloadConfigs()){
+                sender.sendMessage("NuVotifier Has reloaded Successfully");
+            } else {
+                sender.sendMessage("NuVotifier couldn't load properly. Check your config for Errors");
+            }
             return true;
         }
         return false;

--- a/bukkit/src/main/java/com/vexsoftware/votifier/NuVotifierBukkit.java
+++ b/bukkit/src/main/java/com/vexsoftware/votifier/NuVotifierBukkit.java
@@ -42,6 +42,8 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -108,7 +110,40 @@ public class NuVotifierBukkit extends JavaPlugin implements VoteHandler, Votifie
 
         // Set the plugin version.
         version = getDescription().getVersion();
+        reloadConfigs();
 
+
+
+    }
+
+    @Override
+    public void onDisable() {
+        // Shut down the network handlers.
+        if (serverGroup != null) {
+            if (serverChannel != null)
+                serverChannel.close();
+            serverGroup.shutdownGracefully();
+        }
+        if (forwardingMethod != null) {
+            forwardingMethod.halt();
+        }
+        getLogger().info("Votifier disabled.");
+    }
+
+
+    public boolean reloadConfigs(){
+        if (serverGroup != null) {
+            if (serverChannel != null) {
+                serverChannel.close();
+                serverChannel = null;
+            }
+            serverGroup.shutdownGracefully();
+            serverGroup = null;
+        }
+        if (forwardingMethod != null) {
+            forwardingMethod.halt();
+            forwardingMethod = null;
+        }
         if (!getDataFolder().exists()) {
             getDataFolder().mkdir();
         }
@@ -162,7 +197,7 @@ public class NuVotifierBukkit extends JavaPlugin implements VoteHandler, Votifie
             } catch (Exception ex) {
                 getLogger().log(Level.SEVERE, "Error creating configuration file", ex);
                 gracefulExit();
-                return;
+                return false;
             }
         }
 
@@ -185,7 +220,7 @@ public class NuVotifierBukkit extends JavaPlugin implements VoteHandler, Votifie
             getLogger().log(Level.SEVERE,
                     "Error reading configuration file or RSA tokens", ex);
             gracefulExit();
-            return;
+            return false;
         }
 
         debug = cfg.getBoolean("debug", false);
@@ -210,7 +245,7 @@ public class NuVotifierBukkit extends JavaPlugin implements VoteHandler, Votifie
                 getLogger().log(Level.SEVERE,
                         "Error generating Votifier token", e);
                 gracefulExit();
-                return;
+                return false;
             }
             getLogger().info("------------------------------------------------------------------------------");
             getLogger().info("No tokens were found in your configuration, so we've generated one for you.");
@@ -283,20 +318,17 @@ public class NuVotifierBukkit extends JavaPlugin implements VoteHandler, Votifie
                 getLogger().severe("No vote forwarding method '" + method + "' known. Defaulting to noop implementation.");
             }
         }
+
+        return true;
     }
 
     @Override
-    public void onDisable() {
-        // Shut down the network handlers.
-        if (serverGroup != null) {
-            if (serverChannel != null)
-                serverChannel.close();
-            serverGroup.shutdownGracefully();
+    public boolean onCommand(CommandSender sender, Command cmd, String commandLabel, String[] args){
+        if(cmd.getName().equalsIgnoreCase("nvreload")){
+            reloadConfigs();
+            return true;
         }
-        if (forwardingMethod != null) {
-            forwardingMethod.halt();
-        }
-        getLogger().info("Votifier disabled.");
+        return false;
     }
 
     private void gracefulExit() {

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -3,3 +3,9 @@ main: com.vexsoftware.votifier.NuVotifierBukkit
 version: maven-version-number
 description: A plugin that gets notified when votes are made for the server on toplists.
 authors: [blakeman8192, Kramer, tuxed]
+commands:
+   reload:
+      description: This command reloads the NuVotifier Config
+      usage: /nvreload
+      permission: nuvotifier.reload
+      permission-message: You don't have permission to run this command.

--- a/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/NuVotifier.java
+++ b/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/NuVotifier.java
@@ -262,6 +262,7 @@ public class NuVotifier extends Plugin implements VoteHandler, VotifierPlugin {
             initTask.get();
         } catch (InterruptedException | ExecutionException e) {
             throw new RuntimeException("Unable to start server", e);
+
         }
 
         Configuration fwdCfg = configuration.getSection("forwarding");

--- a/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/NuVotifier.java
+++ b/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/NuVotifier.java
@@ -5,6 +5,7 @@ import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
 import com.vexsoftware.votifier.VoteHandler;
 import com.vexsoftware.votifier.VotifierPlugin;
+import com.vexsoftware.votifier.bungee.commands.ReloadCommand;
 import com.vexsoftware.votifier.bungee.events.VotifierEvent;
 import com.vexsoftware.votifier.bungee.forwarding.ForwardingVoteSource;
 import com.vexsoftware.votifier.bungee.forwarding.OnlineForwardPluginMessagingForwardingSource;
@@ -30,7 +31,10 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.config.Configuration;
 import net.md_5.bungee.config.ConfigurationProvider;
@@ -88,6 +92,26 @@ public class NuVotifier extends Plugin implements VoteHandler, VotifierPlugin {
 
     @Override
     public void onEnable() {
+        reloadConfigs();
+        getProxy().getPluginManager().registerCommand(this, new ReloadCommand(this));
+
+    }
+
+    public boolean reloadConfigs(){
+        if (serverGroup != null) {
+            if (serverChannel != null) {
+                serverChannel.close();
+                serverChannel = null;
+            }
+            serverGroup.shutdownGracefully();
+            serverGroup = null;
+        }
+
+        if (forwardingMethod != null) {
+            forwardingMethod.halt();
+            forwardingMethod = null;
+        }
+
         if (!getDataFolder().exists()) {
             getDataFolder().mkdir();
         }
@@ -303,7 +327,10 @@ public class NuVotifier extends Plugin implements VoteHandler, VotifierPlugin {
         } else {
             getLogger().severe("No vote forwarding method '" + fwdMethod + "' known. Defaulting to noop implementation.");
         }
+
+        return true;
     }
+
 
 
     @Override
@@ -319,6 +346,7 @@ public class NuVotifier extends Plugin implements VoteHandler, VotifierPlugin {
 
         getLogger().info("Votifier disabled.");
     }
+
 
     @Override
     public void onVoteReceived(Channel channel, final Vote vote, VotifierSession.ProtocolVersion protocolVersion) throws Exception {

--- a/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/commands/ReloadCommand.java
+++ b/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/commands/ReloadCommand.java
@@ -1,0 +1,32 @@
+package com.vexsoftware.votifier.bungee.commands;
+
+import com.vexsoftware.votifier.bungee.NuVotifier;
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.chat.ComponentBuilder;
+import net.md_5.bungee.api.plugin.Command;
+
+/**
+ * Created by curscascis on 8/20/2017.
+ */
+public class ReloadCommand extends Command{
+    private NuVotifier plugin;
+
+    public ReloadCommand(NuVotifier plugin) {
+        super("nvreload");
+        this.plugin = plugin;
+    }
+
+
+    @Override
+    public void execute(CommandSender commandSender, String[] strings) {
+
+        if((plugin.reloadConfigs())){
+            commandSender.sendMessage(new ComponentBuilder("nuvotifier has been reloaded").color(ChatColor.GREEN).create());
+        } else {
+            commandSender.sendMessage(new ComponentBuilder("nuvotifier has failed while reloading. Check your config.").color(ChatColor.RED).create());
+        }
+    }
+
+
+}

--- a/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/commands/ReloadCommand.java
+++ b/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/commands/ReloadCommand.java
@@ -20,11 +20,12 @@ public class ReloadCommand extends Command{
 
     @Override
     public void execute(CommandSender commandSender, String[] strings) {
-
-        if((plugin.reloadConfigs())){
-            commandSender.sendMessage(new ComponentBuilder("nuvotifier has been reloaded").color(ChatColor.GREEN).create());
-        } else {
-            commandSender.sendMessage(new ComponentBuilder("nuvotifier has failed while reloading. Check your config.").color(ChatColor.RED).create());
+        if(commandSender.hasPermission("nuvotifier.reload")){
+            if ((plugin.reloadConfigs())) {
+                commandSender.sendMessage(new ComponentBuilder("nuvotifier has been reloaded").color(ChatColor.GREEN).create());
+            } else {
+                commandSender.sendMessage(new ComponentBuilder("nuvotifier has failed while reloading. Check your config.").color(ChatColor.RED).create());
+            }
         }
     }
 

--- a/sponge/pom.xml
+++ b/sponge/pom.xml
@@ -42,20 +42,30 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+
+
 
     <dependencies>
         <dependency>
             <groupId>com.vexsoftware</groupId>
             <artifactId>nuvotifier-common</artifactId>
-            <version>${project.parent.version}</version>
+            <version>2.3.5</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.spongepowered</groupId>
             <artifactId>spongeapi</artifactId>
-            <version>5.0.0</version>
+            <version>7.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/sponge/src/main/java/com/vexsoftware/votifier/sponge/VotifierPlugin.java
+++ b/sponge/src/main/java/com/vexsoftware/votifier/sponge/VotifierPlugin.java
@@ -78,7 +78,7 @@ public class VotifierPlugin implements VoteHandler, com.vexsoftware.votifier.Vot
         // Set the plugin version.
         version = this.getClass().getAnnotation(Plugin.class).version();
         registerCommands();
-        reloadConfig();
+        reloadConfigs();
 
 
     }
@@ -100,7 +100,7 @@ public class VotifierPlugin implements VoteHandler, com.vexsoftware.votifier.Vot
     /**
      * Reload the Votifier server on demand. Allows managing ports without requiring a server restart.
      */
-    public boolean reloadConfig(){
+    public boolean reloadConfigs(){
         //Attempt to close previously existing channels
         if (serverGroup != null) {
             if (serverChannel != null) {
@@ -252,7 +252,8 @@ public class VotifierPlugin implements VoteHandler, com.vexsoftware.votifier.Vot
 
         serverGroup = new NioEventLoopGroup(1);
 
-        new ServerBootstrap().channel(NioServerSocketChannel.class)
+        new ServerBootstrap()
+                .channel(NioServerSocketChannel.class)
                 .group(serverGroup)
                 .childHandler(new ChannelInitializer<NioSocketChannel>() {
                     @Override
@@ -415,7 +416,7 @@ public class VotifierPlugin implements VoteHandler, com.vexsoftware.votifier.Vot
     private void registerCommands() {
         CommandSpec reload = CommandSpec.builder()
                 .description(Text.of("Reload Your NuVotifier Config"))
-                .permission("seriousvote.commands.admin.reload")
+                .permission("nuvotifier.reload")
                 .executor(new NVReload())
                 .build();
         Sponge.getCommandManager().register(this, reload, "nvreload");
@@ -425,7 +426,7 @@ public class VotifierPlugin implements VoteHandler, com.vexsoftware.votifier.Vot
     public class NVReload implements CommandExecutor {
         public CommandResult execute(CommandSource src, CommandContext args) throws
                 CommandException {
-            if (reloadConfig()) {
+            if (reloadConfigs()) {
                 src.sendMessage(Text.of("NuVotifier Reloaded successfully!"));
             } else {
                 src.sendMessage(Text.of("Could not reload properly :( did you break your config?").toBuilder().color(TextColors.RED).build());

--- a/sponge/src/main/java/com/vexsoftware/votifier/sponge/VotifierPlugin.java
+++ b/sponge/src/main/java/com/vexsoftware/votifier/sponge/VotifierPlugin.java
@@ -77,7 +77,9 @@ public class VotifierPlugin implements VoteHandler, com.vexsoftware.votifier.Vot
     public void onServerStart(GameStartedServerEvent event) {
         // Set the plugin version.
         version = this.getClass().getAnnotation(Plugin.class).version();
+        registerCommands();
         reloadConfig();
+
 
     }
 

--- a/sponge/src/main/java/com/vexsoftware/votifier/sponge/VotifierPlugin.java
+++ b/sponge/src/main/java/com/vexsoftware/votifier/sponge/VotifierPlugin.java
@@ -40,7 +40,7 @@ import org.spongepowered.api.command.spec.CommandSpec;
 import org.spongepowered.api.config.ConfigDir;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.cause.Cause;
-import org.spongepowered.api.event.cause.NamedCause;
+import org.spongepowered.api.event.cause.EventContext;
 import org.spongepowered.api.event.game.state.GameStartedServerEvent;
 import org.spongepowered.api.event.game.state.GameStoppingServerEvent;
 import org.spongepowered.api.plugin.Plugin;
@@ -379,7 +379,8 @@ public class VotifierPlugin implements VoteHandler, com.vexsoftware.votifier.Vot
                 .execute(new Runnable() {
                     @Override
                     public void run() {
-                        VotifierEvent event = new VotifierEvent(vote, Cause.of(NamedCause.of("Vote", vote)));
+                        VotifierEvent event = new VotifierEvent(vote,Cause.builder().append("Vote").build(EventContext.empty()));
+
                         Sponge.getEventManager().post(event);
                     }
                 })
@@ -405,7 +406,7 @@ public class VotifierPlugin implements VoteHandler, com.vexsoftware.votifier.Vot
                 .execute(new Runnable() {
                     @Override
                     public void run() {
-                        VotifierEvent event = new VotifierEvent(v, Cause.of(NamedCause.of("ForwardedVote", v)));
+                        VotifierEvent event = new VotifierEvent(v,Cause.builder().append("ForwardedVote").build(EventContext.empty()));
                         Sponge.getEventManager().post(event);
                     }
                 })

--- a/universal/pom.xml
+++ b/universal/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>nuvotifier-universal</artifactId>
+    <artifactId>serious-nuvotifier-universal</artifactId>
     <name>nuvotifier</name>
 
     <build>


### PR DESCRIPTION
Hello. I hope this pull request is not much of a burden. I did not see any PR policies in the README. I would have built and published this myself under the same name - (except modified)  but it seems the licensing prohibits me from doing that, to my understanding. and so I'd like to contribute this bit of code which adds a command to NuVotifier (sponge Version) to destroy the previous channels and listening server and to create a new one with the newly loaded configuration.

This is an important change because often times when server owners do start up their voting processes they generally have players online. Having to restart servers over and over again as they troubleshoot here and there, working with server hosts and friends trying to figure out the right setup. All this rebooting is pretty annoying for players. Some servers end up changing dns records, or have ip  or port changes. At the end of the day it's intent is to improve the experience of the players. It's a very useful and needed tool and I am sure it will be used frequently among server owners.