### PR TITLE
Relocate gson

### DIFF
--- a/universal/build.gradle
+++ b/universal/build.gradle
@@ -58,6 +58,7 @@ shadowJar {
     relocate "io.netty", "com.vexsoftware.votifier.io.netty"
     relocate "org.json", "com.vexsoftware.votifier.json"
     relocate new SimpleRelocator("com.google.code", "com.vexsoftware.votifier.google.code", new ArrayList<String>(), Collections.singletonList("com.vexsoftware.votifier.sponge"))
+    relocate "com.google.gson", "com.vexsoftware.votifier.google.gson"
     relocate "org.apache.commons.io", "com.vexsoftware.votifier.commons.io"
 
     transform(NettyEpollTransformer.class)


### PR DESCRIPTION
Prevents potential class loading conflicts with gson present in craftbukkit/spigot.

It is possible that the inclusion of not-relocated gson is the cause of
https://hub.spigotmc.org/jira/browse/SPIGOT-6056?focusedCommentId=37758&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-37758
(also related to konsolas/AAC-Issues#2108 )