### PR TITLE
Prevent NPE when the fallbackServer is null

### DIFF
--- a/velocity/src/main/java/com/vexsoftware/votifier/velocity/OnlineForwardPluginMessagingForwardingSource.java
+++ b/velocity/src/main/java/com/vexsoftware/votifier/velocity/OnlineForwardPluginMessagingForwardingSource.java
@@ -45,7 +45,9 @@ public final class OnlineForwardPluginMessagingForwardingSource extends Abstract
             }
         }
 
-        Optional<RegisteredServer> fs = plugin.getServer().getServer(fallbackServer);
+        Optional<RegisteredServer> fs = fallbackServer == null ?
+                Optional.empty() :
+                plugin.getServer().getServer(fallbackServer);
         // nowhere to fall back to, yet still not online. lets save this vote yet!
         if (!fs.isPresent())
             attemptToAddToPlayerCache(v, v.getUsername());


### PR DESCRIPTION
When the fallbackServer is empty, null is passed to `OnlineForwardPluginMessagingForwardingSource`, which then calls `getServer(fallbackServer)`, resulting in an NPE (https://gyazo.com/9fc7f429715a55a75c199b8cdf8b3ed7). This should fix this NPE so server owners are able to use no fallback servers again.