### PR TITLE
Add compatibility for JDK 9+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ subprojects {
         testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.4.2"
         testImplementation "org.junit.jupiter:junit-jupiter-params:5.4.2"
         testImplementation "org.mockito:mockito-core:2.+"
+        implementation "jakarta.xml.bind:jakarta.xml.bind-api:2.3.2"
+        implementation "org.glassfish.jaxb:jaxb-runtime:2.3.2"
     }
 
     processResources {


### PR DESCRIPTION
Without this, Bungeecord (at least for what I've tested) with Java 16 would produce a fatal startup error:
```
Exception encountered when loading plugin: NuVotifier
java.lang.NoClassDefFoundError: javax/xml/bind/DatatypeConverter
        at com.vexsoftware.votifier.net.protocol.v1crypto.RSAIO.load(RSAIO.java:75) ~[?:?]
        at com.vexsoftware.votifier.bungee.NuVotifier.onEnable(NuVotifier.java:153) ~[?:?]
        at net.md_5.bungee.api.plugin.PluginManager.enablePlugins(PluginManager.java:315) ~[waterfall-patched.jar:git:Waterfall-Bootstrap:1.17-R0.1-SNAPSHOT:d6cfd97:unknown]
        at net.md_5.bungee.BungeeCord.start(BungeeCord.java:290) ~[waterfall-patched.jar:git:Waterfall-Bootstrap:1.17-R0.1-SNAPSHOT:d6cfd97:unknown]
        at net.md_5.bungee.BungeeCordLauncher.main(BungeeCordLauncher.java:67) ~[waterfall-patched.jar:git:Waterfall-Bootstrap:1.17-R0.1-SNAPSHOT:d6cfd97:unknown]
        at net.md_5.bungee.Bootstrap.main(Bootstrap.java:15) ~[waterfall-patched.jar:git:Waterfall-Bootstrap:1.17-R0.1-SNAPSHOT:d6cfd97:unknown]
Caused by: java.lang.ClassNotFoundException: javax.xml.bind.DatatypeConverter
        at net.md_5.bungee.api.plugin.PluginClassloader.loadClass0(PluginClassloader.java:97) ~[waterfall-patched.jar:git:Waterfall-Bootstrap:1.17-R0.1-SNAPSHOT:d6cfd97:unknown]
        at net.md_5.bungee.api.plugin.PluginClassloader.loadClass(PluginClassloader.java:59) ~[waterfall-patched.jar:git:Waterfall-Bootstrap:1.17-R0.1-SNAPSHOT:d6cfd97:unknown]
        at java.lang.ClassLoader.loadClass(ClassLoader.java:519) ~[?:?]
        ... 6 more
```
The added dependencies provide the missing classes that are no longer available JDK 9+.   
[More information](https://stackoverflow.com/a/43574427/11427881)