### PR TITLE
Corrected offline vote caching to be case-insensitive

### DIFF
--- a/common/src/main/java/com/vexsoftware/votifier/support/forwarding/AbstractPluginMessagingForwardingSource.java
+++ b/common/src/main/java/com/vexsoftware/votifier/support/forwarding/AbstractPluginMessagingForwardingSource.java
@@ -96,7 +96,7 @@ public abstract class AbstractPluginMessagingForwardingSource implements Forward
 
     protected void attemptToAddToPlayerCache(Vote v, String player) {
         if (cache != null) {
-            cache.addToCachePlayer(v, player);
+            cache.addToCachePlayer(v, player.toLowerCase());
             if (plugin.isDebug())
                 plugin.getPluginLogger().info("Added to forwarding cache: " + v + " -> (player) " + player);
         } else if (plugin.isDebug())
@@ -151,10 +151,10 @@ public abstract class AbstractPluginMessagingForwardingSource implements Forward
         if (cache == null) return;
         if (!serverFilter.isAllowed(server.getName())) return;
 
-        final Collection<Vote> cachedVotes = cache.evictPlayer(playerName);
+        final Collection<Vote> cachedVotes = cache.evictPlayer(playerName.toLowerCase());
         dumpVotesToServer(cachedVotes, server, "player '" + playerName + "'", failedVotes -> {
             for (Vote v : failedVotes)
-                cache.addToCachePlayer(v, playerName);
+                cache.addToCachePlayer(v, playerName.toLowerCase());
         });
     }
 }


### PR DESCRIPTION
This patch is to mitigate instances where offline votes cast using case-incorrect spelling fails to forward the vote for a player when they next login. The player cannot vote again, and rewards are lost.

Example scenario:

Player with a name Notch (spelled exactly) votes at some website and spells their name using entirely lower-case such as "notch", because they are using a smartphone. The vote is successfully received by the server, but they are unable to receive their reward once they log in, and cannot vote again.

This issue only presents when vote caching is used, which requires `pluginMessaging` to be specified as the forwarding method in the NuVotifier configuration file for BungeeCord. It does not exhibit with the other `proxy` forwarding method, or when NuVotifier is used without BungeeCord.