### PR TITLE
Make unprocessable votes a warning

### DIFF
--- a/bukkit/src/main/java/com/vexsoftware/votifier/NuVotifierBukkit.java
+++ b/bukkit/src/main/java/com/vexsoftware/votifier/NuVotifierBukkit.java
@@ -345,13 +345,13 @@ public class NuVotifierBukkit extends JavaPlugin implements VoteHandler, Votifie
     public void onError(Throwable throwable, boolean alreadyHandledVote, String remoteAddress) {
         if (debug) {
             if (alreadyHandledVote) {
-                getLogger().log(Level.SEVERE, "Vote processed, however an exception " +
+                getLogger().log(Level.WARNING, "Vote processed, however an exception " +
                         "occurred with a vote from " + remoteAddress, throwable);
             } else {
-                getLogger().log(Level.SEVERE, "Unable to process vote from " + remoteAddress, throwable);
+                getLogger().log(Level.WARNING, "Unable to process vote from " + remoteAddress, throwable);
             }
         } else if (!alreadyHandledVote) {
-            getLogger().log(Level.SEVERE, "Unable to process vote from " + remoteAddress);
+            getLogger().log(Level.WARNING, "Unable to process vote from " + remoteAddress);
         }
     }
 

--- a/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/NuVotifier.java
+++ b/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/NuVotifier.java
@@ -376,13 +376,13 @@ public class NuVotifier extends Plugin implements VoteHandler, ProxyVotifierPlug
     public void onError(Throwable throwable, boolean alreadyHandledVote, String remoteAddress) {
         if (debug) {
             if (alreadyHandledVote) {
-                getLogger().log(Level.SEVERE, "Vote processed, however an exception " +
+                getLogger().log(Level.WARNING, "Vote processed, however an exception " +
                         "occurred with a vote from " + remoteAddress, throwable);
             } else {
-                getLogger().log(Level.SEVERE, "Unable to process vote from " + remoteAddress, throwable);
+                getLogger().log(Level.WARNING, "Unable to process vote from " + remoteAddress, throwable);
             }
         } else if (!alreadyHandledVote) {
-            getLogger().log(Level.SEVERE, "Unable to process vote from " + remoteAddress);
+            getLogger().log(Level.WARNING, "Unable to process vote from " + remoteAddress);
         }
     }
 

--- a/sponge/src/main/java/com/vexsoftware/votifier/sponge/NuVotifier.java
+++ b/sponge/src/main/java/com/vexsoftware/votifier/sponge/NuVotifier.java
@@ -273,13 +273,13 @@ public class NuVotifier implements VoteHandler, VotifierPlugin, ForwardedVoteLis
     public void onError(Throwable throwable, boolean alreadyHandledVote, String remoteAddress) {
         if (debug) {
             if (alreadyHandledVote) {
-                logger.error("Vote processed, however an exception " +
+                logger.warn("Vote processed, however an exception " +
                         "occurred with a vote from " + remoteAddress, throwable);
             } else {
-                logger.error("Unable to process vote from " + remoteAddress, throwable);
+                logger.warn("Unable to process vote from " + remoteAddress, throwable);
             }
         } else if (!alreadyHandledVote) {
-            logger.error("Unable to process vote from " + remoteAddress);
+            logger.warn("Unable to process vote from " + remoteAddress);
         }
     }
 

--- a/velocity/src/main/java/com/vexsoftware/votifier/velocity/VotifierPlugin.java
+++ b/velocity/src/main/java/com/vexsoftware/votifier/velocity/VotifierPlugin.java
@@ -402,13 +402,13 @@ public class VotifierPlugin implements VoteHandler, ProxyVotifierPlugin {
     public void onError(Throwable throwable, boolean alreadyHandledVote, String remoteAddress) {
         if (debug) {
             if (alreadyHandledVote) {
-                logger.error("Vote processed, however an exception " +
+                logger.warn("Vote processed, however an exception " +
                         "occurred with a vote from " + remoteAddress, throwable);
             } else {
-                logger.error("Unable to process vote from " + remoteAddress, throwable);
+                logger.warn("Unable to process vote from " + remoteAddress, throwable);
             }
         } else if (!alreadyHandledVote) {
-            logger.error("Unable to process vote from " + remoteAddress);
+            logger.warn("Unable to process vote from " + remoteAddress);
         }
     }
 


### PR DESCRIPTION
This patch changes the error log entry when a vote is not able to be processed by nuvotifier to a warning instead.

Why do we believe this change makes sense?

Our server is still in build up but already configured to receive votes, therefore we know that we don't yet get legitimate votes because no vote sites have been registered where people could submit them.
We never the less get multiple error messages per day from nuvotifier because of invalid votes. I guess this is because people connect to the open port and throw junk at it that nuvotifier doesn't understand.
We argue that an unprocessable vote should not be an error, because nuvotifier does what it is supposed to do and no intervention is needed for the plugin to continue working properly, but rather a warning should be issued because the information that votes fail is valuable nonetheless.