### PR TITLE
Add fabric support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ debug.txt
 # gradle stuff
 .gradle/
 .gradletasknamecache
+
+# fabric
+fabric/run/

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
         url = uri("https://repo.spongepowered.org/repository/maven-public/")
     }
     maven {
-        name = "Fabric"
+        name = "fabric"
         url = uri("https://maven.fabricmc.net/")
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,6 +10,10 @@ repositories {
         name = "sponge"
         url = uri("https://repo.spongepowered.org/repository/maven-public/")
     }
+    maven {
+        name = "Fabric"
+        url = uri("https://maven.fabricmc.net/")
+    }
 }
 
 dependencies {
@@ -18,4 +22,5 @@ dependencies {
     implementation("gradle.plugin.com.github.johnrengelman:shadow:7.1.2")
     implementation("org.jfrog.buildinfo:build-info-extractor-gradle:4.27.1")
     implementation("org.spongepowered:spongegradle-plugin-development:2.0.0")
+    implementation("net.fabricmc:fabric-loom:1.0-SNAPSHOT")
 }

--- a/buildSrc/src/main/kotlin/CommonConfig.kt
+++ b/buildSrc/src/main/kotlin/CommonConfig.kt
@@ -13,6 +13,10 @@ fun Project.applyCommonConfiguration() {
     repositories {
         mavenCentral()
         maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots/") }
+        maven {
+            name = "Fabric"
+            url = uri("https://maven.fabricmc.net/")
+        }
     }
 
     configurations.all {

--- a/bukkit/src/main/java/com/vexsoftware/votifier/BukkitScheduler.java
+++ b/bukkit/src/main/java/com/vexsoftware/votifier/BukkitScheduler.java
@@ -18,21 +18,6 @@ class BukkitScheduler implements VotifierScheduler {
     }
 
     @Override
-    public ScheduledVotifierTask sync(Runnable runnable) {
-        return new BukkitTaskWrapper(plugin.getServer().getScheduler().runTask(plugin, runnable));
-    }
-
-    @Override
-    public ScheduledVotifierTask onPool(Runnable runnable) {
-        return new BukkitTaskWrapper(plugin.getServer().getScheduler().runTaskAsynchronously(plugin, runnable));
-    }
-
-    @Override
-    public ScheduledVotifierTask delayedSync(Runnable runnable, int delay, TimeUnit unit) {
-        return new BukkitTaskWrapper(plugin.getServer().getScheduler().runTaskLater(plugin, runnable, toTicks(delay, unit)));
-    }
-
-    @Override
     public ScheduledVotifierTask delayedOnPool(Runnable runnable, int delay, TimeUnit unit) {
         return new BukkitTaskWrapper(plugin.getServer().getScheduler().runTaskLaterAsynchronously(plugin, runnable, toTicks(delay, unit)));
     }

--- a/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/BungeeScheduler.java
+++ b/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/BungeeScheduler.java
@@ -14,21 +14,6 @@ class BungeeScheduler implements VotifierScheduler {
     }
 
     @Override
-    public ScheduledVotifierTask sync(Runnable runnable) {
-        return onPool(runnable);
-    }
-
-    @Override
-    public ScheduledVotifierTask onPool(Runnable runnable) {
-        return new BungeeTaskWrapper(plugin.getProxy().getScheduler().runAsync(plugin, runnable));
-    }
-
-    @Override
-    public ScheduledVotifierTask delayedSync(Runnable runnable, int delay, TimeUnit unit) {
-        return delayedOnPool(runnable, delay, unit);
-    }
-
-    @Override
     public ScheduledVotifierTask delayedOnPool(Runnable runnable, int delay, TimeUnit unit) {
         return new BungeeTaskWrapper(plugin.getProxy().getScheduler().schedule(plugin, runnable, delay, unit));
     }

--- a/common/src/main/java/com/vexsoftware/votifier/platform/scheduler/ScheduledExecutorServiceVotifierScheduler.java
+++ b/common/src/main/java/com/vexsoftware/votifier/platform/scheduler/ScheduledExecutorServiceVotifierScheduler.java
@@ -13,21 +13,6 @@ public class ScheduledExecutorServiceVotifierScheduler implements VotifierSchedu
     }
 
     @Override
-    public ScheduledVotifierTask sync(Runnable runnable) {
-        return new ScheduledVotifierTaskWrapper(service.submit(runnable));
-    }
-
-    @Override
-    public ScheduledVotifierTask onPool(Runnable runnable) {
-        return new ScheduledVotifierTaskWrapper(service.submit(runnable));
-    }
-
-    @Override
-    public ScheduledVotifierTask delayedSync(Runnable runnable, int delay, TimeUnit unit) {
-        return new ScheduledVotifierTaskWrapper(service.schedule(runnable, delay, unit));
-    }
-
-    @Override
     public ScheduledVotifierTask delayedOnPool(Runnable runnable, int delay, TimeUnit unit) {
         return new ScheduledVotifierTaskWrapper(service.schedule(runnable, delay, unit));
     }

--- a/common/src/main/java/com/vexsoftware/votifier/platform/scheduler/VotifierScheduler.java
+++ b/common/src/main/java/com/vexsoftware/votifier/platform/scheduler/VotifierScheduler.java
@@ -3,11 +3,6 @@ package com.vexsoftware.votifier.platform.scheduler;
 import java.util.concurrent.TimeUnit;
 
 public interface VotifierScheduler {
-    ScheduledVotifierTask sync(Runnable runnable);
-
-    ScheduledVotifierTask onPool(Runnable runnable);
-
-    ScheduledVotifierTask delayedSync(Runnable runnable, int delay, TimeUnit unit);
 
     ScheduledVotifierTask delayedOnPool(Runnable runnable, int delay, TimeUnit unit);
 

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,0 +1,74 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import net.fabricmc.loom.task.RemapJarTask
+
+plugins {
+    `java-library`
+    id("fabric-loom")
+}
+
+applyPlatformAndCoreConfiguration()
+applyCommonArtifactoryConfig()
+applyShadowConfiguration()
+
+configurations {
+    compileClasspath.get().extendsFrom(create("shadeOnly"))
+}
+
+dependencies {
+    minecraft("com.mojang:minecraft:1.19.4")
+    mappings(loom.officialMojangMappings())
+    modImplementation("net.fabricmc:fabric-loader:0.14.19")
+
+    // Make a set of all api modules we wish to use
+    setOf(
+        "fabric-api-base",
+        "fabric-command-api-v2",
+        "fabric-lifecycle-events-v1",
+        "fabric-networking-api-v1"
+    ).forEach {
+        // Add each module as a dependency
+        modImplementation(fabricApi.module(it, "0.80.0+1.19.4"))
+    }
+
+    "implementation"("org.yaml:snakeyaml:2.0")
+    "modImplementation"("me.lucko:fabric-permissions-api:0.2-SNAPSHOT")
+    "include"("me.lucko:fabric-permissions-api:0.2-SNAPSHOT")
+
+
+    "api"(project(":nuvotifier-api"))
+    "api"(project(":nuvotifier-common"))
+}
+
+tasks.named<Copy>("processResources") {
+    val internalVersion = project.ext["internalVersion"]
+    inputs.property("internalVersion", internalVersion)
+    filesMatching("fabric.mod.json") {
+        expand("internalVersion" to internalVersion)
+    }
+}
+
+tasks.named<ShadowJar>("shadowJar") {
+    configurations = listOf(project.configurations["shadeOnly"], project.configurations["runtimeClasspath"])
+
+    archiveClassifier.set("dist-dev")
+
+    dependencies {
+        relocate("org.yaml", "com.vexsoftware.votifier.libs.org.yaml")
+        include(dependency(":nuvotifier-api"))
+        include(dependency(":nuvotifier-common"))
+        include(dependency("org.yaml:snakeyaml:"))
+    }
+    exclude("mappings/mappings.tiny")
+}
+
+tasks.register<RemapJarTask>("remapShadowJar") {
+    val shadowJar = tasks.getByName<ShadowJar>("shadowJar")
+    dependsOn(shadowJar)
+    inputFile.set(shadowJar.archiveFile)
+    archiveFileName.set(shadowJar.archiveFileName.get().replace(Regex("-dev\\.jar$"), ".jar"))
+    addNestedDependencies.set(true)
+}
+
+tasks.named("assemble").configure {
+    dependsOn("remapShadowJar")
+}

--- a/fabric/src/main/java/com/vexsoftware/votifier/fabric/NuVotifier.java
+++ b/fabric/src/main/java/com/vexsoftware/votifier/fabric/NuVotifier.java
@@ -1,0 +1,270 @@
+package com.vexsoftware.votifier.fabric;
+
+import com.vexsoftware.votifier.VoteHandler;
+import com.vexsoftware.votifier.fabric.cmd.NuVotifierCommand;
+import com.vexsoftware.votifier.fabric.config.ConfigLoader;
+import com.vexsoftware.votifier.fabric.event.VoteListener;
+import com.vexsoftware.votifier.fabric.forwarding.FabricMessagingForwardingSink;
+import com.vexsoftware.votifier.model.Vote;
+import com.vexsoftware.votifier.net.VotifierServerBootstrap;
+import com.vexsoftware.votifier.net.VotifierSession;
+import com.vexsoftware.votifier.net.protocol.v1crypto.RSAIO;
+import com.vexsoftware.votifier.net.protocol.v1crypto.RSAKeygen;
+import com.vexsoftware.votifier.platform.LoggingAdapter;
+import com.vexsoftware.votifier.platform.VotifierPlugin;
+import com.vexsoftware.votifier.platform.scheduler.ScheduledExecutorServiceVotifierScheduler;
+import com.vexsoftware.votifier.platform.scheduler.VotifierScheduler;
+import com.vexsoftware.votifier.support.forwarding.ForwardedVoteListener;
+import com.vexsoftware.votifier.support.forwarding.ForwardingVoteSink;
+import com.vexsoftware.votifier.util.KeyCreator;
+import net.fabricmc.api.DedicatedServerModInitializer;
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.server.MinecraftServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.security.Key;
+import java.security.KeyPair;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
+
+public class NuVotifier implements VoteHandler, VotifierPlugin, ForwardedVoteListener, DedicatedServerModInitializer {
+
+    public static final Logger LOGGER = LoggerFactory.getLogger("nuvotifier");
+
+    private SLF4JLogger loggerAdapter;
+
+
+    public File configDir = FabricLoader.getInstance().getConfigDir().toFile();
+
+    private VotifierScheduler scheduler;
+
+    private boolean loadAndBind() {
+        // Load configuration.
+        ConfigLoader.loadConfig(this);
+
+        /*
+         * Create RSA directory and keys if it does not exist; otherwise, read
+         * keys.
+         */
+        File rsaDirectory = new File(configDir, "rsa");
+        try {
+            if (!rsaDirectory.exists()) {
+                if (!rsaDirectory.mkdir()) {
+                    throw new RuntimeException("Unable to create the RSA key folder " + rsaDirectory);
+                }
+                keyPair = RSAKeygen.generate(2048);
+                RSAIO.save(rsaDirectory, keyPair);
+            } else {
+                keyPair = RSAIO.load(rsaDirectory);
+            }
+        } catch (Exception ex) {
+            LOGGER.error("Error creating or reading RSA tokens", ex);
+            return false;
+        }
+
+        debug = ConfigLoader.getFabricConfig().debug;
+
+        // Load Votifier tokens.
+        ConfigLoader.getFabricConfig().tokens.forEach((s, s2) -> {
+            tokens.put(s, KeyCreator.createKeyFrom(s2));
+            LOGGER.info("Loaded token for website: " + s);
+        });
+
+        // Initialize the receiver.
+        final String host = ConfigLoader.getFabricConfig().host;
+        final int port = ConfigLoader.getFabricConfig().port;
+
+        if (!debug)
+            LOGGER.info("QUIET mode enabled!");
+
+        if (port >= 0) {
+            final boolean disablev1 = ConfigLoader.getFabricConfig().disableV1Protocol;
+            if (disablev1) {
+                LOGGER.info("------------------------------------------------------------------------------");
+                LOGGER.info("Votifier protocol v1 parsing has been disabled. Most voting websites do not");
+                LOGGER.info("currently support the modern Votifier protocol in NuVotifier.");
+                LOGGER.info("------------------------------------------------------------------------------");
+            }
+
+            this.bootstrap = new VotifierServerBootstrap(host, port, this, disablev1);
+            this.bootstrap.start(err -> {
+            });
+        } else {
+            LOGGER.info("------------------------------------------------------------------------------");
+            LOGGER.info("Your Votifier port is less than 0, so we assume you do NOT want to start the");
+            LOGGER.info("votifier port server! Votifier will not listen for votes over any port, and");
+            LOGGER.info("will only listen for pluginMessaging forwarded votes!");
+            LOGGER.info("------------------------------------------------------------------------------");
+        }
+
+        if (ConfigLoader.getFabricConfig().forwarding != null) {
+            String method = ConfigLoader.getFabricConfig().forwarding.method.toLowerCase(); //Default to lower case for case-insensitive searches
+            if ("none".equals(method)) {
+                LOGGER.info("Method none selected for vote forwarding: Votes will not be received from a forwarder.");
+            } else if ("pluginmessaging".equals(method)) {
+                String channel = ConfigLoader.getFabricConfig().forwarding.pluginMessaging.channel;
+                try {
+                    forwardingMethod = new FabricMessagingForwardingSink(channel, this);
+                    LOGGER.info("Receiving votes over PluginMessaging channel '" + channel + "'.");
+                } catch (RuntimeException e) {
+                    LOGGER.error("NuVotifier could not set up PluginMessaging for vote forwarding!", e);
+                }
+            } else {
+                LOGGER.error("No vote forwarding method '" + method + "' known. Defaulting to noop implementation.");
+            }
+        }
+        return true;
+    }
+
+    private void halt() {
+        // Shut down the network handlers.
+        if (bootstrap != null) {
+            bootstrap.shutdown();
+            bootstrap = null;
+        }
+
+        if (forwardingMethod != null) {
+            forwardingMethod.halt();
+            forwardingMethod = null;
+        }
+    }
+
+    public boolean reload() {
+        try {
+            halt();
+        } catch (Exception ex) {
+            LOGGER.error("On halt, an exception was thrown. This may be fine!", ex);
+        }
+
+        if (loadAndBind()) {
+            LOGGER.info("Reload was successful.");
+            return true;
+        } else {
+            try {
+                halt();
+                LOGGER.error("On reload, there was a problem with the configuration. Votifier currently does nothing!");
+            } catch (Exception ex) {
+                LOGGER.error("On reload, there was a problem loading, and we could not re-halt the server. Votifier is in an unstable state!", ex);
+            }
+            return false;
+        }
+    }
+
+    /**
+     * The server bootstrap.
+     */
+    private VotifierServerBootstrap bootstrap;
+
+    /**
+     * The RSA key pair.
+     */
+    private KeyPair keyPair;
+
+    /**
+     * Debug mode flag
+     */
+    private boolean debug;
+
+    /**
+     * Keys used for websites.
+     */
+    private final Map<String, Key> tokens = new HashMap<>();
+
+    private ForwardingVoteSink forwardingMethod;
+
+    private MinecraftServer server;
+
+    @Override
+    public void onInitializeServer() {
+        CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> NuVotifierCommand.register(this, dispatcher));
+        ServerLifecycleEvents.END_DATA_PACK_RELOAD.register((server, resourceManager, success) -> this.reload());
+        ServerLifecycleEvents.SERVER_STARTING.register(this::onServerStart);
+        ServerLifecycleEvents.SERVER_STOPPING.register(this::onServerStop);
+    }
+
+    private void onServerStart(MinecraftServer server) {
+        this.server = server;
+        this.scheduler = new ScheduledExecutorServiceVotifierScheduler(Executors.newScheduledThreadPool(1));
+        this.loggerAdapter = new SLF4JLogger(LOGGER);
+        if (!loadAndBind()) {
+            LOGGER.error("Votifier did not initialize properly!");
+        }
+    }
+
+    private void onServerStop(MinecraftServer server) {
+        halt();
+        LOGGER.info("Votifier disabled.");
+    }
+
+    public File getConfigDir() {
+        return configDir;
+    }
+
+    @Override
+    public void onVoteReceived(Vote vote, VotifierSession.ProtocolVersion protocolVersion, String remoteAddress) {
+        if (debug) {
+            if (protocolVersion == VotifierSession.ProtocolVersion.ONE) {
+                LOGGER.info("Got a protocol v1 vote record from " + remoteAddress + " -> " + vote);
+            } else {
+                LOGGER.info("Got a protocol v2 vote record from " + remoteAddress + " -> " + vote);
+            }
+        }
+        this.fireVoteEvent(vote);
+    }
+
+    @Override
+    public void onError(Throwable throwable, boolean alreadyHandledVote, String remoteAddress) {
+        if (debug) {
+            if (alreadyHandledVote) {
+                LOGGER.error("Vote processed, however an exception " +
+                        "occurred with a vote from " + remoteAddress, throwable);
+            } else {
+                LOGGER.error("Unable to process vote from " + remoteAddress, throwable);
+            }
+        } else if (!alreadyHandledVote) {
+            LOGGER.error("Unable to process vote from " + remoteAddress);
+        }
+    }
+
+    @Override
+    public Map<String, Key> getTokens() {
+        return tokens;
+    }
+
+    @Override
+    public KeyPair getProtocolV1Key() {
+        return keyPair;
+    }
+
+    @Override
+    public LoggingAdapter getPluginLogger() {
+        return loggerAdapter;
+    }
+
+    @Override
+    public VotifierScheduler getScheduler() {
+        return scheduler;
+    }
+
+    @Override
+    public boolean isDebug() {
+        return debug;
+    }
+
+    @Override
+    public void onForward(final Vote v) {
+        if (debug) {
+            LOGGER.info("Got a forwarded vote -> " + v);
+        }
+        fireVoteEvent(v);
+    }
+
+    private void fireVoteEvent(final Vote vote) {
+        server.submit(() -> VoteListener.EVENT.invoker().onVote(vote));
+    }
+}

--- a/fabric/src/main/java/com/vexsoftware/votifier/fabric/SLF4JLogger.java
+++ b/fabric/src/main/java/com/vexsoftware/votifier/fabric/SLF4JLogger.java
@@ -1,0 +1,47 @@
+package com.vexsoftware.votifier.fabric;
+
+import com.vexsoftware.votifier.platform.LoggingAdapter;
+import org.slf4j.Logger;
+
+public class SLF4JLogger implements LoggingAdapter {
+
+    private final Logger l;
+    public SLF4JLogger(Logger l) {
+        this.l = l;
+    }
+
+    @Override
+    public void error(String s) {
+        l.error(s);
+    }
+
+    @Override
+    public void error(String s, Object... o) {
+        l.error(s, o);
+    }
+
+    @Override
+    public void error(String s, Throwable e, Object... o) {
+        l.error(s, e, o);
+    }
+
+    @Override
+    public void warn(String s) {
+        l.warn(s);
+    }
+
+    @Override
+    public void warn(String s, Object... o) {
+        l.warn(s, o);
+    }
+
+    @Override
+    public void info(String s) {
+        l.info(s);
+    }
+
+    @Override
+    public void info(String s, Object... o) {
+        l.info(s, o);
+    }
+}

--- a/fabric/src/main/java/com/vexsoftware/votifier/fabric/cmd/NuVotifierCommand.java
+++ b/fabric/src/main/java/com/vexsoftware/votifier/fabric/cmd/NuVotifierCommand.java
@@ -1,0 +1,66 @@
+package com.vexsoftware.votifier.fabric.cmd;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.vexsoftware.votifier.fabric.NuVotifier;
+import com.vexsoftware.votifier.model.Vote;
+import com.vexsoftware.votifier.net.VotifierSession;
+import com.vexsoftware.votifier.util.ArgsToVote;
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.chat.Component;
+
+import java.util.function.Predicate;
+
+import static net.minecraft.commands.Commands.argument;
+import static net.minecraft.commands.Commands.literal;
+
+public class NuVotifierCommand {
+
+    private static NuVotifier plugin;
+
+    public static void register(NuVotifier plugin, CommandDispatcher<CommandSourceStack> dispatcher) {
+        NuVotifierCommand.plugin = plugin;
+        Predicate<CommandSourceStack> reloadPerm = Permissions.require("nuvotifier.reload", 2);
+        Predicate<CommandSourceStack> testVotePerm = Permissions.require("nuvotifier.testvote", 2);
+        dispatcher.register(
+                literal("nuvotifier").requires(reloadPerm.or(testVotePerm))
+                        .then(
+                        literal("reload").requires(reloadPerm)
+                                .executes(NuVotifierCommand::reload)
+                ).then(
+                        literal("testvote").then(
+                                argument("args", StringArgumentType.greedyString()).requires(testVotePerm)
+                                        .executes(NuVotifierCommand::sendTestVote)
+                        )
+                )
+        );
+    }
+
+    private static int reload(CommandContext<CommandSourceStack> ctx) {
+        ctx.getSource().sendSuccess(Component.literal("Reloading NuVotifier...").withStyle(ChatFormatting.GRAY), false);
+        if (plugin.reload()) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+
+    private static int sendTestVote(CommandContext<CommandSourceStack> ctx) {
+        Vote v;
+        try {
+            String args = StringArgumentType.getString(ctx, "args");
+            v = ArgsToVote.parse(args.split(" "));
+        } catch (IllegalArgumentException e) {
+            ctx.getSource().sendFailure(Component.literal("Error while parsing arguments to create test vote: " + e.getMessage()).withStyle(ChatFormatting.DARK_RED));
+            ctx.getSource().sendFailure(Component.literal("Usage hint: /testvote [username] [serviceName=?] [username=?] [address=?] [localTimestamp=?] [timestamp=?]").withStyle(ChatFormatting.GRAY));
+            return 0;
+        }
+        plugin.onVoteReceived(v, VotifierSession.ProtocolVersion.TEST, "localhost.test");
+
+        return 1;
+    }
+
+}

--- a/fabric/src/main/java/com/vexsoftware/votifier/fabric/config/ConfigLoader.java
+++ b/fabric/src/main/java/com/vexsoftware/votifier/fabric/config/ConfigLoader.java
@@ -1,0 +1,54 @@
+package com.vexsoftware.votifier.fabric.config;
+
+import com.vexsoftware.votifier.fabric.NuVotifier;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Representer;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+
+public class ConfigLoader {
+
+    private static FabricConfig fabricConfig;
+    private static Yaml yaml;
+
+    public static void loadConfig(NuVotifier pl) {
+        DumperOptions options = new DumperOptions();
+        options.setPrettyFlow(true);
+
+        Representer representer = new Representer(options);
+        representer.addClassTag(FabricConfig.class, Tag.MAP);
+        yaml = new Yaml(representer, options);
+
+        if (!pl.getConfigDir().exists()) {
+            if (!pl.getConfigDir().mkdirs()) {
+                throw new RuntimeException("Unable to create the plugin data folder " + pl.getConfigDir());
+            }
+        }
+        try {
+            File config = new File(pl.getConfigDir(), "nuvotifier.yml");
+            if (!config.exists()) {
+                if (!config.createNewFile()) {
+                    throw new IOException("Unable to create the config file at " + config);
+                }
+                FileWriter fileWriter = new FileWriter(config);
+                // Save the default config
+                yaml.dump(new FabricConfig(), fileWriter);
+                fileWriter.flush();
+            }
+            fabricConfig = yaml.loadAs(Files.newInputStream(config.toPath()), FabricConfig.class);
+        } catch (Exception e) {
+            NuVotifier.LOGGER.error("Could not load config.", e);
+        }
+    }
+
+    public static FabricConfig getFabricConfig() {
+        return fabricConfig;
+    }
+
+
+}

--- a/fabric/src/main/java/com/vexsoftware/votifier/fabric/config/FabricConfig.java
+++ b/fabric/src/main/java/com/vexsoftware/votifier/fabric/config/FabricConfig.java
@@ -1,0 +1,35 @@
+package com.vexsoftware.votifier.fabric.config;
+
+import com.vexsoftware.votifier.util.TokenUtil;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class FabricConfig {
+
+    public String host = "0.0.0.0";
+
+    public int port = 8192;
+
+    public boolean debug = true;
+
+    public boolean disableV1Protocol = false;
+
+    public Map<String, String> tokens = Collections.singletonMap("default", TokenUtil.newToken());
+
+    public Forwarding forwarding = new Forwarding();
+
+    public static class Forwarding {
+
+        public String method = "none";
+
+        public PluginMessaging pluginMessaging = new PluginMessaging();
+
+        public static class PluginMessaging {
+
+            public String channel = "nuvotifier:votes";
+
+        }
+    }
+
+}

--- a/fabric/src/main/java/com/vexsoftware/votifier/fabric/event/VoteListener.java
+++ b/fabric/src/main/java/com/vexsoftware/votifier/fabric/event/VoteListener.java
@@ -1,0 +1,17 @@
+package com.vexsoftware.votifier.fabric.event;
+
+import com.vexsoftware.votifier.model.Vote;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+public interface VoteListener {
+
+    Event<VoteListener> EVENT = EventFactory.createArrayBacked(VoteListener.class, (voteListeners) -> (vote) -> {
+        for (VoteListener voteListener : voteListeners) {
+            voteListener.onVote(vote);
+        }
+    });
+
+    void onVote(Vote vote);
+
+}

--- a/fabric/src/main/java/com/vexsoftware/votifier/fabric/forwarding/FabricMessagingForwardingSink.java
+++ b/fabric/src/main/java/com/vexsoftware/votifier/fabric/forwarding/FabricMessagingForwardingSink.java
@@ -28,10 +28,8 @@ public class FabricMessagingForwardingSink extends AbstractPluginMessagingForwar
 
     @Override
     public void receive(MinecraftServer server, ServerPlayer player, ServerGamePacketListenerImpl handler, FriendlyByteBuf buf, PacketSender responseSender) {
-        byte[] data = new byte[buf.capacity()];
-        for (int i = 0; i < buf.capacity(); i++) {
-            data[i] = buf.getByte(i);
-        }
+        byte[] data = new byte[buf.readableBytes()];
+        buf.readBytes(data);
         try {
             this.handlePluginMessage(data);
         } catch (Exception e) {

--- a/fabric/src/main/java/com/vexsoftware/votifier/fabric/forwarding/FabricMessagingForwardingSink.java
+++ b/fabric/src/main/java/com/vexsoftware/votifier/fabric/forwarding/FabricMessagingForwardingSink.java
@@ -1,0 +1,41 @@
+package com.vexsoftware.votifier.fabric.forwarding;
+
+import com.vexsoftware.votifier.fabric.NuVotifier;
+import com.vexsoftware.votifier.support.forwarding.AbstractPluginMessagingForwardingSink;
+import com.vexsoftware.votifier.support.forwarding.ForwardedVoteListener;
+import net.fabricmc.fabric.api.networking.v1.PacketSender;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+
+public class FabricMessagingForwardingSink extends AbstractPluginMessagingForwardingSink implements ServerPlayNetworking.PlayChannelHandler {
+
+    private final String channel;
+
+    public FabricMessagingForwardingSink(String channel, ForwardedVoteListener listener) {
+        super(listener);
+        this.channel = channel;
+        ServerPlayNetworking.registerGlobalReceiver(new ResourceLocation(channel), this);
+    }
+
+    @Override
+    public void halt() {
+        ServerPlayNetworking.unregisterGlobalReceiver(new ResourceLocation(channel));
+    }
+
+    @Override
+    public void receive(MinecraftServer server, ServerPlayer player, ServerGamePacketListenerImpl handler, FriendlyByteBuf buf, PacketSender responseSender) {
+        byte[] data = new byte[buf.capacity()];
+        for (int i = 0; i < buf.capacity(); i++) {
+            data[i] = buf.getByte(i);
+        }
+        try {
+            this.handlePluginMessage(data);
+        } catch (Exception e) {
+            NuVotifier.LOGGER.error("There was an unknown error when processing a forwarded vote.", e);
+        }
+    }
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": 1,
+  "id": "nuvotifier",
+  "version": "${internalVersion}",
+
+  "name": "NuVotifier",
+  "description": "Safe, smart, and secure Votifier server mod",
+  "authors": [
+    "Drex"
+  ],
+  "license": "GPLv3",
+  "environment": "server",
+  "entrypoints": {
+    "server": [
+      "com.vexsoftware.votifier.fabric.NuVotifier"
+    ]
+  },
+  "depends": {
+    "fabric-api-base": "*",
+    "fabric-command-api-v2": "*",
+    "fabric-lifecycle-events-v1": "*",
+    "fabric-networking-api-v1": "*"
+  }
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -2,7 +2,6 @@
   "schemaVersion": 1,
   "id": "nuvotifier",
   "version": "${internalVersion}",
-
   "name": "NuVotifier",
   "description": "Safe, smart, and secure Votifier server mod",
   "authors": [

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
+org.gradle.jvmargs=-Xmx4G
 group=com.vexsoftware
 version=3.0.0-SNAPSHOT

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,8 @@ include("nuvotifier-bungeecord")
 project(":nuvotifier-bungeecord").projectDir = file("bungeecord")
 include("nuvotifier-sponge")
 project(":nuvotifier-sponge").projectDir = file("sponge")
+include("nuvotifier-fabric")
+project(":nuvotifier-fabric").projectDir = file("fabric")
 include("nuvotifier-velocity")
 project(":nuvotifier-velocity").projectDir = file("velocity")
 

--- a/sponge/src/main/java/com/vexsoftware/votifier/sponge/SpongeScheduler.java
+++ b/sponge/src/main/java/com/vexsoftware/votifier/sponge/SpongeScheduler.java
@@ -19,21 +19,6 @@ class SpongeScheduler implements VotifierScheduler {
     }
 
     @Override
-    public ScheduledVotifierTask sync(Runnable runnable) {
-        return new TaskWrapper(taskBuilder(runnable).submit(plugin));
-    }
-
-    @Override
-    public ScheduledVotifierTask onPool(Runnable runnable) {
-        return new TaskWrapper(taskBuilder(runnable).async().submit(plugin));
-    }
-
-    @Override
-    public ScheduledVotifierTask delayedSync(Runnable runnable, int delay, TimeUnit unit) {
-        return new TaskWrapper(taskBuilder(runnable).delay(delay, unit).submit(plugin));
-    }
-
-    @Override
     public ScheduledVotifierTask delayedOnPool(Runnable runnable, int delay, TimeUnit unit) {
         return new TaskWrapper(taskBuilder(runnable).delay(delay, unit).async().submit(plugin));
     }

--- a/universal/build.gradle.kts
+++ b/universal/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     "implementation"(project(":nuvotifier-bukkit"))
     "implementation"(project(":nuvotifier-bungeecord"))
     "implementation"(project(":nuvotifier-sponge"))
+    "implementation"(project(":nuvotifier-fabric"))
     "implementation"(project(":nuvotifier-velocity"))
 }
 
@@ -37,6 +38,7 @@ tasks.named<ShadowJar>("shadowJar") {
         include(dependency(":nuvotifier-bukkit"))
         include(dependency(":nuvotifier-bungeecord"))
         include(dependency(":nuvotifier-sponge"))
+        include(dependency(":nuvotifier-fabric"))
         include(dependency(":nuvotifier-velocity"))
     }
 

--- a/velocity/src/main/java/com/vexsoftware/votifier/velocity/VelocityScheduler.java
+++ b/velocity/src/main/java/com/vexsoftware/votifier/velocity/VelocityScheduler.java
@@ -22,21 +22,6 @@ class VelocityScheduler implements VotifierScheduler {
     }
 
     @Override
-    public ScheduledVotifierTask sync(Runnable runnable) {
-        return onPool(runnable);
-    }
-
-    @Override
-    public ScheduledVotifierTask onPool(Runnable runnable) {
-        return new TaskWrapper(builder(runnable).schedule());
-    }
-
-    @Override
-    public ScheduledVotifierTask delayedSync(Runnable runnable, int delay, TimeUnit unit) {
-        return delayedOnPool(runnable, delay, unit);
-    }
-
-    @Override
     public ScheduledVotifierTask delayedOnPool(Runnable runnable, int delay, TimeUnit unit) {
         return new TaskWrapper(builder(runnable).delay(delay, unit).schedule());
     }


### PR DESCRIPTION
This PR adds support for [fabric](https://fabricmc.net/) to this project. I have mostly used the sponge module for a guide on implementing everything on fabric. I have tested using the mod as a standalone votifier and "pluginmessaging" forwarding methods. Usage of NMS has been kept to a minimum to increase cross version compatibility.

This PR gets rid of some methods in `VotifierScheduler`, because they are unused and would have been annoying to implement on fabric (which doesn't provide a scheduler itself)